### PR TITLE
Fix initialization failure when flavor is set to quartz

### DIFF
--- a/libs/ngx-cron-editor/src/cron-editor.component.ts
+++ b/libs/ngx-cron-editor/src/cron-editor.component.ts
@@ -449,7 +449,7 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
 
   private getDefaultState() {
     const [defaultHours, defaultMinutes, defaultSeconds] = this.options.defaultTime.split(':').map(Number);
-
+    this.localCron = this.isCronFlavorQuartz ? '* 0 0 ? * * *' : '0 0 1/1 * *';
     return {
       minutes: {
         minutes: 1,


### PR DESCRIPTION
Fix initialization failure when flavor is set to quartz.  If CronOption `cronFlavor: "quartz"` is set, the initialization fails and the component does not render.