### PR TITLE
Add possible location of bug

### DIFF
--- a/libs/ngx-cron-editor/src/cron-editor.component.ts
+++ b/libs/ngx-cron-editor/src/cron-editor.component.ts
@@ -79,6 +79,7 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
    * The cron output value is updated whenever a form is updated. To make it change in response to tab selection, we simply reset
    * the value of the form that goes into focus. */
   public onTabFocus(idx: number) {
+    // The bug is here as the idx changes when tabs are 'hidden'. E.g. when the minutes are hidden, then the hour tab has index 0
     switch (idx) {
       case 0:
         this.minutesForm.setValue(this.minutesForm.value);


### PR DESCRIPTION
Hi, I think I found a bug. I did not know where the file an issue, so I created a PR here.
When tabs are hidden via `CronOptions`, the default value of the cron expression when switching between the tabs is wrong.
E.g. when I hide the minutes tab, and I switch to the daily tab, the value of the cron expression is set to once per hour (which is the default value for the hour tab).
I think I already found the location of the bug.
I will try to come up with a PR to fix this.