### PR TITLE
15 initial cron expression is not loaded in the form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.7.9-0](https://github.com/haavardj/ngx-cron-editor/compare/v0.7.8...v0.7.9-0) (2023-08-14)
+
+
+### Bug Fixes
+
+* incorrenct values ([fcb8614](https://github.com/haavardj/ngx-cron-editor/commit/fcb86144b2f1b7969a773c0b43ccd308b6e96f93))
+* values not updated in forms ([d33d90d](https://github.com/haavardj/ngx-cron-editor/commit/d33d90d5f4b9ebb06d6f82f1dadd5f2780601eef))
+
 ### [0.7.8](https://github.com/haavardj/ngx-cron-editor/compare/v0.7.7...v0.7.8) (2023-07-04)
 
 

--- a/apps/demo/src/app/app.component.html
+++ b/apps/demo/src/app/app.component.html
@@ -2,41 +2,78 @@
 
   <h1>Angular Cron Expression Editor</h1>
 
-    <mat-card appearance="outlined" class="demo-card">
-      <mat-card-header class="demo-card-header">
-
-        <mat-card-title>
-          Select your cron flavor
-        </mat-card-title>
-        <div>
+  <mat-card class="input-cart" >
+    <mat-card-header>
+      <mat-card-title>
+        <h2>Select Type</h2>
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="input-card-content">
           <mat-form-field>
             <mat-label>Flavor</mat-label>
             <mat-select (change)="cronFlavorChange()" [(ngModel)]="cronOptions.cronFlavor">
               <mat-option [value]="'quartz'">
                 Quartz
               </mat-option>
-
               <mat-option [value]="'standard'">
                 Standard
               </mat-option>
             </mat-select>
           </mat-form-field>
-        </div>
-      </mat-card-header>
+    </mat-card-content>
+  </mat-card>
 
-      <mat-card-content class="demo-card-content">
-        <form >
-        <cron-editor  #cronEditorDemo [formControl]="cronForm"  [options]="cronOptions">Cron here...</cron-editor>
-        </form>
-      </mat-card-content>
+<form>
+  <mat-card appearance="outlined" class="demo-card" [formGroup]="form">
+    <mat-card-header class="demo-card-header">
+      <mat-card-title>
+        <h2>Reactive Form</h2>
 
-      <mat-card-footer class="demo-card-footer">
-        <div>
-          <h3>
-            <b>Expression: {{cronForm.value}}</b>
-          </h3>
-        </div>
-      </mat-card-footer>
+        <mat-form-field>
+          <mat-label>Initial Cron</mat-label>
+          <input type="text" matInput formControlName="expression">
+        </mat-form-field>
 
-    </mat-card>
+        <!-- Form change not emitted to cron editor without setting the expression manually. Not sure why! -->
+        <mat-button-toggle (click)="form.patchValue({expression: form.value.expression})">Update</mat-button-toggle>
+
+      </mat-card-title>
+    </mat-card-header>
+
+    <mat-card-content class="demo-card-content">
+      <cron-editor  #cronEditorDemo2  formControlName="expression"  [options]="cronOptions">Cron here...</cron-editor>
+    </mat-card-content>
+    <mat-card-footer class="demo-card-footer">
+      <div>
+        <h3>
+          <b>Expression: {{this.form.controls.expression.value}}</b>
+        </h3>
+      </div>
+    </mat-card-footer>
+  </mat-card>
+</form>
+
+  <!--  <mat-card appearance="outlined" class="demo-card">
+    <mat-card-header>
+      <mat-card-title class="input-card-content">
+        Template Driven
+        <mat-form-field>
+          <mat-label>Initial Cron</mat-label>
+          <input matInput [(ngModel)]="cronExpression" >
+        </mat-form-field>
+
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="demo-card-content">
+      <cron-editor  #cronEditorDemo1 [(ngModel)]="cronExpression"  [options]="cronOptions">Cron here...</cron-editor>
+    </mat-card-content>
+    <mat-card-footer class="demo-card-footer">
+      <div>
+        <h3>
+          <b>Expression: {{cronExpression}}</b>
+        </h3>
+      </div>
+    </mat-card-footer>
+  </mat-card>-->
+
 </section>

--- a/apps/demo/src/app/app.component.scss
+++ b/apps/demo/src/app/app.component.scss
@@ -1,12 +1,28 @@
 @use '@angular/material' as mat;
 
+.input-cart{
+  margin-bottom: 12px;
+  width: 780px;
+}
+
+.input-card-content{
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 .demo-container {
   margin: 30px;
 }
 
 .demo-card {
   @include mat.elevation(2);
-  position: absolute;
+  margin-bottom: 12px;
+}
+
+.demo-card mat-button-toggle {
+  margin-left: 7px;
 }
 
 .demo-card-header {

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import { CronOptions } from 'ngx-cron-editor';
+import {DefaultOptions} from 'ngx-cron-editor';
 import { CronGenComponent } from 'ngx-cron-editor';
-import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
+import {FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-root',
@@ -9,31 +9,10 @@ import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  public cronExpression = '0 0 1/1 * *';
+  public cronExpression = '1 1 1/1 * *';
   public isCronDisabled = false;
-  public cronOptions: CronOptions = {
-    formInputClass: 'form-control cron-editor-input',
-    formSelectClass: 'form-control cron-editor-select',
-    formRadioClass: 'cron-editor-radio',
-    formCheckboxClass: 'cron-editor-checkbox',
+  public cronOptions = new DefaultOptions();
 
-    defaultTime: '00:00:00',
-
-    hideMinutesTab: false,
-    hideHourlyTab: false,
-    hideDailyTab: false,
-    hideWeeklyTab: false,
-    hideMonthlyTab: false,
-    hideYearlyTab: false,
-    hideAdvancedTab: false,
-    hideSpecificWeekDayTab: false,
-    hideSpecificMonthWeekTab: false,
-
-    use24HourTime: true,
-    hideSeconds: false,
-
-    cronFlavor: 'standard'
-  };
 
   @ViewChild('cronEditorDemo')
   cronEditorDemo: CronGenComponent;

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -9,7 +9,7 @@ import {FormControl } from '@angular/forms';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  public cronExpression = '1 1 1/1 * *';
+  public cronExpression = '3 23/45 1 1/1 * *';
   public isCronDisabled = false;
   public cronOptions = new DefaultOptions();
 
@@ -18,7 +18,10 @@ export class AppComponent implements OnInit {
   cronEditorDemo: CronGenComponent;
 
   cronForm = new FormControl(this.cronExpression);
-  constructor() {}
+  constructor() {
+    this.cronOptions.cronFlavor = 'quartz';
+
+  }
 
   ngOnInit(): void {}
 

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -38,13 +38,10 @@ export class AppComponent implements OnInit {
   @ViewChild('cronEditorDemo')
   cronEditorDemo: CronGenComponent;
 
-  cronForm: FormControl;
-
+  cronForm = new FormControl(this.cronExpression);
   constructor() {}
 
-  ngOnInit(): void {
-    this.cronForm = new FormControl(this.cronExpression);
-  }
+  ngOnInit(): void {}
 
   cronFlavorChange() {
     this.cronEditorDemo.options = this.cronOptions;

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
 import {DefaultOptions} from 'ngx-cron-editor';
 import { CronGenComponent } from 'ngx-cron-editor';
-import {FormControl } from '@angular/forms';
+import {FormBuilder, FormControl} from '@angular/forms';
 
 @Component({
   selector: 'app-root',
@@ -9,20 +9,29 @@ import {FormControl } from '@angular/forms';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  public cronExpression = '0/20 1 1/1 * *';
+  public cronExpression = '5/3 3 1/1 * *';
   public isCronDisabled = false;
   public cronOptions = new DefaultOptions();
 
 
-  @ViewChild('cronEditorDemo')
-  cronEditorDemo: CronGenComponent;
+  @ViewChild('cronEditorDemo1')
+  cronEditorDemo1: CronGenComponent;
 
-  cronForm = new FormControl(this.cronExpression);
-  constructor() {}
+  @ViewChild('cronEditorDemo2')
+  cronEditorDemo2: CronGenComponent;
 
-  ngOnInit(): void {}
+  form = this.fb.group({
+    expression: [this.cronExpression]
+  })
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    // this.form.valueChanges.subscribe( val  => {console.log(JSON.stringify(val)) })
+  }
 
   cronFlavorChange() {
-    this.cronEditorDemo.options = this.cronOptions;
+    this.cronEditorDemo1.options = this.cronOptions;
+    this.cronEditorDemo2.options = this.cronOptions;
   }
 }

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -9,7 +9,7 @@ import {FormControl } from '@angular/forms';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  public cronExpression = '3 23/45 1 1/1 * *';
+  public cronExpression = '0/20 1 1/1 * *';
   public isCronDisabled = false;
   public cronOptions = new DefaultOptions();
 
@@ -18,10 +18,7 @@ export class AppComponent implements OnInit {
   cronEditorDemo: CronGenComponent;
 
   cronForm = new FormControl(this.cronExpression);
-  constructor() {
-    this.cronOptions.cronFlavor = 'quartz';
-
-  }
+  constructor() {}
 
   ngOnInit(): void {}
 

--- a/apps/demo/src/app/app.module.ts
+++ b/apps/demo/src/app/app.module.ts
@@ -14,6 +14,9 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSliderModule } from '@angular/material/slider';
 import { CronEditorModule } from 'ngx-cron-editor';
 import { AppComponent } from './app.component';
+import {MatInputModule} from '@angular/material/input';
+import {MatListModule} from '@angular/material/list';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
 
 @NgModule({
   imports: [
@@ -30,7 +33,11 @@ import { AppComponent } from './app.component';
     MatIconModule,
     MatButtonModule,
     LayoutModule,
-    CronEditorModule],
+    CronEditorModule,
+    MatInputModule,
+    MatListModule,
+    MatButtonToggleModule
+  ],
   declarations: [AppComponent],
   bootstrap: [AppComponent],
   providers: [

--- a/libs/ngx-cron-editor/package.json
+++ b/libs/ngx-cron-editor/package.json
@@ -2,7 +2,7 @@
   "$schema": "./node_modules/ng-packagr/package.schema.json",
   "description": "A cron expression generator for Angular 6+",
   "name": "ngx-cron-editor",
-  "version": "0.7.8",
+  "version": "0.7.9-0",
   "repository": {
     "type": "git",
     "url": "git://github.com/haavardj/ngx-cron-editor"

--- a/libs/ngx-cron-editor/src/CronOptions.ts
+++ b/libs/ngx-cron-editor/src/CronOptions.ts
@@ -1,3 +1,5 @@
+export type CronFlavor = 'standard' | 'quartz';
+
 export interface CronOptions {
     formInputClass?: string;
     formSelectClass?: string;
@@ -19,5 +21,21 @@ export interface CronOptions {
     use24HourTime: boolean;
     hideSeconds: boolean;
 
-    cronFlavor: string;
+    cronFlavor: CronFlavor;
+}
+
+export class DefaultOptions implements  CronOptions {
+  cronFlavor: CronFlavor = 'standard';
+  defaultTime = '00:00:00';
+  hideAdvancedTab = false;
+  hideDailyTab = false;
+  hideHourlyTab = false;
+  hideMinutesTab = false;
+  hideMonthlyTab = false;
+  hideSeconds = false;
+  hideSpecificMonthWeekTab = false;
+  hideSpecificWeekDayTab = false;
+  hideWeeklyTab = false;
+  hideYearlyTab = false;
+  use24HourTime = true;
 }

--- a/libs/ngx-cron-editor/src/CronOptions.ts
+++ b/libs/ngx-cron-editor/src/CronOptions.ts
@@ -25,6 +25,12 @@ export interface CronOptions {
 }
 
 export class DefaultOptions implements  CronOptions {
+
+  formInputClass: 'form-control cron-editor-input';
+  formSelectClass: 'form-control cron-editor-select';
+  formRadioClass: 'cron-editor-radio';
+  formCheckboxClass: 'cron-editor-checkbox';
+
   cronFlavor: CronFlavor = 'standard';
   defaultTime = '00:00:00';
   hideAdvancedTab = false;

--- a/libs/ngx-cron-editor/src/cron-editor.component.css
+++ b/libs/ngx-cron-editor/src/cron-editor.component.css
@@ -6,8 +6,8 @@
 }
 
 .cron-editor-tab-content {
-  width: 1000px;
-  height: 200px;
+  width: 850px;
+  height: 280px;
   margin-top: 24px;
   border-radius: 8px;
 }
@@ -50,6 +50,7 @@
 .cron-editor-radio-group {
   flex-direction: column;
   margin: 15px 0;
+  display: inline-flex;
 }
 
 .cron-editor-radio-button {

--- a/libs/ngx-cron-editor/src/cron-editor.component.css
+++ b/libs/ngx-cron-editor/src/cron-editor.component.css
@@ -6,6 +6,7 @@
 }
 
 .cron-editor-tab-content {
+  width: 1000px;
   height: 200px;
   margin-top: 24px;
   border-radius: 8px;
@@ -38,8 +39,15 @@
   cursor: pointer;
 }
 
-.cron-editor-radio-group {
+.cron-editor-daily {
   display: flex;
+}
+
+.cron-editor-dail-hours {
+  align-self: center;
+}
+
+.cron-editor-radio-group {
   flex-direction: column;
   margin: 15px 0;
 }

--- a/libs/ngx-cron-editor/src/cron-editor.component.css
+++ b/libs/ngx-cron-editor/src/cron-editor.component.css
@@ -6,8 +6,6 @@
 }
 
 .cron-editor-tab-content {
-  width: 850px;
-  height: 280px;
   margin-top: 24px;
   border-radius: 8px;
 }
@@ -32,7 +30,6 @@
 }
 
 .cron-editor-main .cron-editor-container .hour-types {
-  width: 70px;
 }
 
 .nav-tabs li a {

--- a/libs/ngx-cron-editor/src/cron-editor.component.ts
+++ b/libs/ngx-cron-editor/src/cron-editor.component.ts
@@ -155,8 +155,6 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
     const currentTab = tabChangeEvent.tab;
     let x: CronType;
 
-    console.log('on tab change');
-
     switch (currentTab) {
       case this.minutesTab:
         x = 'minutely';
@@ -189,6 +187,8 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
   public async ngOnInit() {
     this.allForm.valueChanges.pipe(skip(1), debounceTime(50)).subscribe(value => {
 
+      console.log('onValueChanged...  ' + JSON.stringify(value));
+
       const cron = this.computeCron();
       // this.allForm.controls.expression.setValue(cron, {emitEvent: false});
       this.cronChange.emit(cron);
@@ -203,11 +203,11 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
       case 'minutely':
         cron = this.computeMinutesCron();
         break;
-      case 'daily':
-        cron = this.computeDailyCron();
-        break;
       case 'hourly':
         cron = this.computeHourlyCron();
+        break;
+      case 'daily':
+        cron = this.computeDailyCron();
         break;
       case 'weekly':
         cron = this.computeWeeklyCron();
@@ -280,9 +280,9 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
     const state = this.allForm.value;
 
     if (state.specificWeekDay) {
-      return `${this.isCronFlavorQuartz ? state.seconds : ''} ${state.minutes} ${this.hourToCron(state.hours, state.hoursType)} ${this.monthDayDefaultChar} 1/${state.months} ${state.day}${state.monthsWeek} ${this.yearDefaultChar}`.trim();
+      return `${this.isCronFlavorQuartz ? state.seconds : ''} ${state.minutes} ${this.hourToCron(state.hours, state.hoursType)} ${this.monthDayDefaultChar} 1/${state.monthsInc} ${state.day}${state.monthsWeek} ${this.yearDefaultChar}`.trim();
     }
-    return `${this.isCronFlavorQuartz ? state.seconds : ''} ${state.minutes} ${this.hourToCron(state.hours, state.hoursType)} ${state.day} 1/${state.months} ${this.weekDayDefaultChar} ${this.yearDefaultChar}`.trim();
+    return `${this.isCronFlavorQuartz ? state.seconds : ''} ${state.minutes} ${this.hourToCron(state.hours, state.hoursType)} ${state.days} 1/${state.monthsInc} ${this.weekDayDefaultChar} ${this.yearDefaultChar}`.trim();
   }
 
   private computeYearlyCron(): string {

--- a/libs/ngx-cron-editor/src/cron-editor.component.ts
+++ b/libs/ngx-cron-editor/src/cron-editor.component.ts
@@ -44,27 +44,21 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
   @ViewChild('minutesTab')
   minutesTab: MatTab;
 
-  hourlyForm: FormGroup;
   @ViewChild('hourlyTab')
   hourlyTab: MatTab;
 
-  dailyForm: FormGroup;
   @ViewChild('dailyTab')
   dailyTab: MatTab;
 
-  weeklyForm: FormGroup;
   @ViewChild('weeklyTab')
   weeklyTab: MatTab;
 
-  monthlyForm: FormGroup;
   @ViewChild('monthlyTab')
   monthlyTab: MatTab;
 
-  yearlyForm: FormGroup;
   @ViewChild('yearlyTab')
   yearlyTab: MatTab;
 
-  advancedForm: FormGroup;
   @ViewChild('advancedTab')
   advancedTab: MatTab;
 
@@ -124,6 +118,9 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
   onTabChange(tabChangeEvent: MatTabChangeEvent) {
     const currentTab = tabChangeEvent.tab;
     let x: CronType;
+
+    console.log('on tab change');
+
     switch (currentTab) {
       case this.minutesTab:
         x = 'minutely';
@@ -148,9 +145,9 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
         break;
       default:
         throw (new Error('Invalid tab selected'));
-
-        this.allForm.value.cronType = x;
     }
+
+    this.allForm.controls.cronType.setValue(x);
   }
 
   public async ngOnInit() {
@@ -186,6 +183,9 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
       default:
         throw Error('Unknown cron type ' + this.allForm.value.cronType);
     }
+
+    console.log(cron);
+    console.log(this.allForm.value.cronType);
 
     this.cronForm.setValue(cron);
   }

--- a/libs/ngx-cron-editor/src/cron-editor.component.ts
+++ b/libs/ngx-cron-editor/src/cron-editor.component.ts
@@ -1,16 +1,12 @@
 import {Component, Input, Output, OnInit, EventEmitter, forwardRef, ViewChild} from '@angular/core';
 import {CronOptions, DefaultOptions} from './CronOptions';
 import { Days, MonthWeeks, Months } from './enums';
-import {ControlValueAccessor, FormBuilder, FormControl, FormGroup, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {ControlValueAccessor, FormBuilder, FormControl, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import { ThemePalette } from '@angular/material/core';
 import {MatTab, MatTabChangeEvent} from '@angular/material/tabs';
-import {parse} from 'jasmine-spec-reporter/built/configuration-parser';
-import {debounceTime, throttleTime} from 'rxjs';
+import {debounceTime} from 'rxjs';
 
 type CronType = 'minutely' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'unknown';
-
-type numberOrAny = number | '*';
-type cronAny = '*';
 
 const minutesExp = /\d+ 0\/\d+ \* 1\/1 \* [\?\*] \*/;
 const hourlyExp = /\d+ \d+ 0\/\d+ 1\/1 \* [\?\*] \*/;
@@ -191,8 +187,6 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
 
   private computeCron() {
 
-    console.log('ComputeCron');
-
     let cron: string;
     switch (this.allForm.value.cronType) {
       case 'minutely':
@@ -220,12 +214,10 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
         throw Error('Unknown cron type ' + this.allForm.value.cronType);
     }
 
-
-    console.log(cron);
-
     this.allForm.controls.expression.setValue(cron, {emitEvent: false});
     this.cronForm.setValue(cron);
     this.cronChange.emit(cron);
+    this.onChange(cron);
   }
 
   private computeMinutesCron(): string {
@@ -441,7 +433,6 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
     // Year
     // Not supported
 
-
     if (cron.match(minutesExp)) {
       this.allForm.controls.cronType.setValue('minutely');
 
@@ -492,93 +483,6 @@ export class CronGenComponent implements OnInit, ControlValueAccessor {
     return false;
   }
 
-  private getDefaultState() {
-    const [defaultHours, defaultMinutes, defaultSeconds] = this.options.defaultTime.split(':').map(Number);
-    this.localCron = this.isCronFlavorQuartz ? '* 0 0 ? * * *' : '0 0 1/1 * *';
-    return {
-      minutes: {
-        minutes: 1,
-        seconds: 0
-      },
-      hourly: {
-        hours: 1,
-        minutes: 0,
-        seconds: 0
-      },
-      daily: {
-        subTab: 'everyDays',
-        everyDays: {
-          days: 1,
-          hours: this.getAmPmHour(defaultHours),
-          minutes: defaultMinutes,
-          seconds: defaultSeconds,
-          hourType: this.getHourType(defaultHours)
-        },
-        everyWeekDay: {
-          hours: this.getAmPmHour(defaultHours),
-          minutes: defaultMinutes,
-          seconds: defaultSeconds,
-          hourType: this.getHourType(defaultHours)
-        }
-      },
-      weekly: {
-        MON: true,
-        TUE: false,
-        WED: false,
-        THU: false,
-        FRI: false,
-        SAT: false,
-        SUN: false,
-        hours: this.getAmPmHour(defaultHours),
-        minutes: defaultMinutes,
-        seconds: defaultSeconds,
-        hourType: this.getHourType(defaultHours)
-      },
-      monthly: {
-        subTab: 'specificDay',
-        specificDay: {
-          day: '1',
-          months: 1,
-          hours: this.getAmPmHour(defaultHours),
-          minutes: defaultMinutes,
-          seconds: defaultSeconds,
-          hourType: this.getHourType(defaultHours)
-        },
-        specificWeekDay: {
-          monthWeek: '#1',
-          day: 'MON',
-          months: 1,
-          hours: this.getAmPmHour(defaultHours),
-          minutes: defaultMinutes,
-          seconds: defaultSeconds,
-          hourType: this.getHourType(defaultHours)
-        }
-      },
-      yearly: {
-        subTab: 'specificMonthDay',
-        specificMonthDay: {
-          month: 1,
-          day: '1',
-          hours: this.getAmPmHour(defaultHours),
-          minutes: defaultMinutes,
-          seconds: defaultSeconds,
-          hourType: this.getHourType(defaultHours)
-        },
-        specificMonthWeek: {
-          monthWeek: '#1',
-          day: 'MON',
-          month: 1,
-          hours: this.getAmPmHour(defaultHours),
-          minutes: defaultMinutes,
-          seconds: defaultSeconds,
-          hourType: this.getHourType(defaultHours)
-        }
-      },
-      advanced: {
-        expression: this.isCronFlavorQuartz ? '0 15 10 L-2 * ? *' : '15 10 2 * *'
-      }
-    };
-  }
 
   private getOrdinalSuffix(value: string) {
     if (value.length > 1) {

--- a/libs/ngx-cron-editor/src/cron-editor.module.ts
+++ b/libs/ngx-cron-editor/src/cron-editor.module.ts
@@ -9,19 +9,21 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatTabsModule } from '@angular/material/tabs';
 import { TimePickerComponent } from './cron-time-picker.component';
 import { CronGenComponent } from './cron-editor.component';
+import {MatGridListModule} from '@angular/material/grid-list';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    FormsModule,
-    ReactiveFormsModule,
-    MatTabsModule,
-    MatListModule,
-    MatSelectModule,
-    MatInputModule,
-    MatRadioModule,
-    MatCheckboxModule
-  ],
+    imports: [
+        CommonModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatTabsModule,
+        MatListModule,
+        MatSelectModule,
+        MatInputModule,
+        MatRadioModule,
+        MatCheckboxModule,
+        MatGridListModule
+    ],
   exports: [TimePickerComponent, CronGenComponent],
   declarations: [TimePickerComponent, CronGenComponent]
 })

--- a/libs/ngx-cron-editor/src/cron-editor.template.html
+++ b/libs/ngx-cron-editor/src/cron-editor.template.html
@@ -6,7 +6,7 @@
       <div class="cron-editor-tab-content">
         <span class="cron-form-label">Every </span>
           <cron-time-picker
-            [formGroup]="minutesForm"
+            [formGroup]="allForm"
             [use24HourTime]="options.use24HourTime"
             [hideHours]="true"
             [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
@@ -18,7 +18,7 @@
     <mat-tab class="cron-editor-tab" label="Hourly" *ngIf="!options.hideHourlyTab" #hourlyTab>
       <div class="cron-editor-tab-content">
         <span class="cron-form-label">Every </span>
-        <cron-time-picker [formGroup]="hourlyForm"
+        <cron-time-picker [formGroup]="allForm"
                           [use24HourTime]="options.use24HourTime"
                           [hideSeconds]="options.hideSeconds ||  !isCronFlavorQuartz">
         </cron-time-picker>
@@ -27,7 +27,7 @@
 
     <!-- Daily-->
     <mat-tab class="cron-editor-tab" label="Daily" *ngIf="!options.hideDailyTab" #dailyTab>
-      <div class="cron-editor-tab-content" [formGroup]="dailyForm">
+      <div class="cron-editor-tab-content" [formGroup]="allForm">
 
         <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
           <mat-radio-button name="subTab" class="cron-editor-radio-button" value="everyDays" [ngClass]="state.formRadioClass" checked="checked">
@@ -74,7 +74,7 @@
 
         <span class="cron-form-label">Every </span>
 
-        <div [formGroup]="weeklyForm">
+        <div [formGroup]="allForm">
           <mat-checkbox class="checkbox-margin" formControlName="MON">Monday</mat-checkbox>
           <mat-checkbox class="checkbox-margin" formControlName="TUE">Tuesday</mat-checkbox>
           <mat-checkbox class="checkbox-margin" formControlName="WED">Wednesday</mat-checkbox>
@@ -86,7 +86,7 @@
 
         <span class="cron-form-label">at time </span>
 
-        <cron-time-picker [formGroup]="weeklyForm"
+        <cron-time-picker [formGroup]="allForm"
                           [use24HourTime]="options.use24HourTime"
                           [hideSeconds]="options.hideSeconds|| !isCronFlavorQuartz">
         </cron-time-picker>
@@ -95,7 +95,7 @@
 
     <!-- Monthly-->
     <mat-tab class="cron-editor-tab" label="Monthly" *ngIf="!options.hideMonthlyTab" #monthlyTab>
-      <div class="cron-editor-tab-content" [formGroup]="monthlyForm">
+      <div class="cron-editor-tab-content" [formGroup]="allForm">
         <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
 
           <mat-radio-button name="monthly-radio" class="cron-editor-radio-button" value="specificDay" [ngClass]="state.formRadioClass">
@@ -141,7 +141,7 @@
 
               at time
 
-              <cron-time-picker [disabled]="disabled" [formGroup]="monthlyForm.controls.specificDay"
+              <cron-time-picker [disabled]="disabled" [formGroup]="allForm.controls.specificDay"
                                 [use24HourTime]="options.use24HourTime"
                                 [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
               </cron-time-picker>
@@ -185,7 +185,7 @@
 
               at time
 
-              <cron-time-picker [formGroup]="monthlyForm.controls.specificWeekDay"
+              <cron-time-picker [formGroup]="allForm.controls.specificWeekDay"
                                 [use24HourTime]="options.use24HourTime"
                                 [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
               </cron-time-picker>
@@ -236,7 +236,7 @@
             at time
 
             <cron-time-picker [disabled]="disabled"
-                              [formGroup]="yearlyForm.controls.specificMonthDay"
+                              [formGroup]="allForm.controls.specificMonthDay"
                               [use24HourTime]="options.use24HourTime"
                               [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
             </cron-time-picker>
@@ -278,7 +278,7 @@
             at time
 
             <cron-time-picker [disabled]="disabled"
-                              [formGroup]="yearlyForm.controls.specificMonthWeek"
+                              [formGroup]="allForm.controls.specificMonthWeek"
                               [use24HourTime]="options.use24HourTime"
                               [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
             </cron-time-picker>

--- a/libs/ngx-cron-editor/src/cron-editor.template.html
+++ b/libs/ngx-cron-editor/src/cron-editor.template.html
@@ -26,15 +26,15 @@
     </mat-tab>
 
     <!-- Daily-->
-    <mat-tab class="cron-editor-tab" label="Daily" *ngIf="!options.hideDailyTab" #dailyTab>
+    <!--    <mat-tab class="cron-editor-tab" label="Daily" *ngIf="!options.hideDailyTab" #dailyTab>
       <div class="cron-editor-tab-content" [formGroup]="allForm">
 
-        <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
-          <mat-radio-button name="subTab" class="cron-editor-radio-button" value="everyDays" [ngClass]="state.formRadioClass" checked="checked">
+        <mat-radio-group class="cron-editor-radio-group" formControlName="weekdaysOnly">
+          <mat-radio-button name="subTab" class="cron-editor-radio-button" value="false" [ngClass]="options.formRadioClass" checked="checked">
 
             <span class="cron-form-label">Every </span>
 
-            <mat-form-field formGroupName="everyDays">
+            <mat-form-field>
               <mat-label>Day(s)</mat-label>
               <mat-select formControlName="days">
                 <mat-option *ngFor="let monthDay of selectOptions.monthDays" [value]="monthDay">
@@ -46,19 +46,19 @@
               at
 
             <cron-time-picker
-              formGroupName="everyDays"
+              formGroupName="allForm"
               [use24HourTime]="options.use24HourTime"
               [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
             </cron-time-picker>
 
           </mat-radio-button>
 
-          <mat-radio-button name="subTab" class="cron-editor-radio-button" value="everyWeekDay" [ngClass]="state.formRadioClass">
+          <mat-radio-button name="subTab" class="cron-editor-radio-button" value="true" [ngClass]="options.formRadioClass">
 
             <span>Week Day (MON-FRI) at </span>
 
             <cron-time-picker
-              formGroupName="everyWeekDay"
+              formGroupName="allForm"
               [use24HourTime]="options.use24HourTime"
               [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
             </cron-time-picker>
@@ -66,10 +66,10 @@
           </mat-radio-button>
         </mat-radio-group>
       </div>
-    </mat-tab>
+    </mat-tab>-->
 
     <!-- Weekly-->
-    <mat-tab  class="cron-editor-tab" label="Weekly" *ngIf="!options.hideWeeklyTab" #weeklyTab>
+<!--    <mat-tab  class="cron-editor-tab" label="Weekly" *ngIf="!options.hideWeeklyTab" #weeklyTab>
       <div class="cron-editor-tab-content">
 
         <span class="cron-form-label">Every </span>
@@ -91,15 +91,15 @@
                           [hideSeconds]="options.hideSeconds|| !isCronFlavorQuartz">
         </cron-time-picker>
       </div>
-    </mat-tab>
+    </mat-tab>-->
 
     <!-- Monthly-->
-    <mat-tab class="cron-editor-tab" label="Monthly" *ngIf="!options.hideMonthlyTab" #monthlyTab>
+<!--    <mat-tab class="cron-editor-tab" label="Monthly" *ngIf="!options.hideMonthlyTab" #monthlyTab>
       <div class="cron-editor-tab-content" [formGroup]="allForm">
         <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
 
           <mat-radio-button name="monthly-radio" class="cron-editor-radio-button" value="specificDay" [ngClass]="state.formRadioClass">
-            <!-- Spesific day -->
+            &lt;!&ndash; Spesific day &ndash;&gt;
             <span formGroupName="specificDay">
 
               On the
@@ -141,7 +141,7 @@
 
               at time
 
-              <cron-time-picker [disabled]="disabled" [formGroup]="allForm.controls.specificDay"
+              <cron-time-picker [disabled]="disabled" [formGroup]="allForm"
                                 [use24HourTime]="options.use24HourTime"
                                 [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
               </cron-time-picker>
@@ -149,7 +149,7 @@
           </mat-radio-button>
 
           <mat-radio-button name="monthly-radio" class="cron-editor-radio-button" value="specificWeekDay" [ngClass]="state.formRadioClass">
-            <!-- Spesific Week day -->
+            &lt;!&ndash; Spesific Week day &ndash;&gt;
             <span formGroupName="specificWeekDay">
 
               On the
@@ -185,7 +185,7 @@
 
               at time
 
-              <cron-time-picker [formGroup]="allForm.controls.specificWeekDay"
+              <cron-time-picker [formGroup]="allForm"
                                 [use24HourTime]="options.use24HourTime"
                                 [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
               </cron-time-picker>
@@ -194,10 +194,10 @@
 
         </mat-radio-group>
       </div>
-    </mat-tab>
+    </mat-tab>-->
 
     <!-- Yearly-->
-    <mat-tab class="cron-editor-tab"  label="Yearly" *ngIf="!options.hideYearlyTab" #yearlyTab>
+<!--    <mat-tab class="cron-editor-tab"  label="Yearly" *ngIf="!options.hideYearlyTab" #yearlyTab>
       <div class="cron-editor-tab-content" [formGroup]="yearlyForm">
         <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
           <mat-radio-button name="yearly-radio" class="cron-editor-radio-button" value="specificMonthDay" [ngClass]="state.formRadioClass">
@@ -236,7 +236,7 @@
             at time
 
             <cron-time-picker [disabled]="disabled"
-                              [formGroup]="allForm.controls.specificMonthDay"
+                              [formGroup]="allForm"
                               [use24HourTime]="options.use24HourTime"
                               [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
             </cron-time-picker>
@@ -278,23 +278,26 @@
             at time
 
             <cron-time-picker [disabled]="disabled"
-                              [formGroup]="allForm.controls.specificMonthWeek"
+                              [formGroup]="allForm"
                               [use24HourTime]="options.use24HourTime"
                               [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
             </cron-time-picker>
           </mat-radio-button>
         </mat-radio-group>
       </div>
-    </mat-tab>
+    </mat-tab>-->
 
     <!-- Advanced-->
-    <mat-tab class="cron-editor-tab" label="Advanced" *ngIf="!options.hideAdvancedTab" #advancedTab>
+<!--    <mat-tab class="cron-editor-tab" label="Advanced" *ngIf="!options.hideAdvancedTab" #advancedTab>
       <div class="cron-editor-tab-content" [formGroup]="advancedForm">
         <mat-form-field>
           <mat-label>Expression</mat-label>
           <input matInput type="text" class="advanced-cron-editor-input" formControlName="expression">
         </mat-form-field>
       </div>
-    </mat-tab>
+    </mat-tab>-->
+
+
+
   </mat-tab-group>
 </section>

--- a/libs/ngx-cron-editor/src/cron-editor.template.html
+++ b/libs/ngx-cron-editor/src/cron-editor.template.html
@@ -2,7 +2,7 @@
   <mat-tab-group class="cron-editor-container" (selectedTabChange)="onTabChange($event)" [backgroundColor]="backgroundColor" [color]="color">
 
     <!-- Minute -->
-    <mat-tab class="cron-editor-tab" label="Minutes" *ngIf="!options.hideMinutesTab" #minutesTab>
+    <mat-tab class="cron-editor-tab" label="Minutely" *ngIf="!options.hideMinutesTab" #minutesTab>
       <div class="cron-editor-tab-content">
         <span class="cron-form-label">Every </span>
           <cron-time-picker

--- a/libs/ngx-cron-editor/src/cron-editor.template.html
+++ b/libs/ngx-cron-editor/src/cron-editor.template.html
@@ -2,105 +2,127 @@
   <mat-tab-group class="cron-editor-container" (selectedTabChange)="onTabChange($event)" [backgroundColor]="backgroundColor" [color]="color">
 
     <!-- Minute -->
-    <mat-tab class="cron-editor-tab" label="Minutely" *ngIf="!options.hideMinutesTab" #minutesTab>
-      <div class="cron-editor-tab-content">
-        <span class="cron-form-label">Every </span>
+    <mat-tab [formGroup]="allForm" class="cron-editor-tab" label="Minutely" *ngIf="!options.hideMinutesTab" #minutesTab>
+      <div class="cron-editor-tab-content" (click)="allForm.controls.cronType.setValue('minutely')">
+
+        <div>
+          <span class="cron-form-label">Every </span>
+          <mat-form-field>
+            <mat-label>Minute(s)</mat-label>
+            <mat-select formControlName="minutesPer">
+              <mat-option *ngFor="let minute of minutes" [value]="minute">{{minute}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div *ngIf="isCronFlavorQuartz">
+          <span> At </span>
           <cron-time-picker
             [formGroup]="allForm"
+            [hideHours] = true
+            [hideMinutes] = true
             [use24HourTime]="options.use24HourTime"
-            [hideHours]="true"
             [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
           </cron-time-picker>
+        </div>
+
       </div>
     </mat-tab>
 
     <!-- Hourly -->
-    <mat-tab class="cron-editor-tab" label="Hourly" *ngIf="!options.hideHourlyTab" #hourlyTab>
-      <div class="cron-editor-tab-content">
-        <span class="cron-form-label">Every </span>
-        <cron-time-picker [formGroup]="allForm"
-                          [use24HourTime]="options.use24HourTime"
-                          [hideSeconds]="options.hideSeconds ||  !isCronFlavorQuartz">
-        </cron-time-picker>
+    <mat-tab  class="cron-editor-tab" label="Hourly" *ngIf="!options.hideHourlyTab" #hourlyTab>
+      <div class="cron-editor-tab-content" (click)="allForm.controls.cronType.setValue('hourly')">
+        <div>
+          <span class="cron-form-label">Every </span>
+          <mat-form-field [formGroup]="allForm">
+            <mat-label>Hour(s)</mat-label>
+            <mat-select formControlName="hoursPer">
+              <mat-option *ngFor="let hour of hours" [value]="hour">{{hour}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div>
+          <span> At </span>
+          <cron-time-picker
+              [formGroup]="allForm"
+              [hideHours] = true
+              [use24HourTime]="options.use24HourTime"
+              [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
+          </cron-time-picker>
+        </div>
       </div>
     </mat-tab>
 
     <!-- Daily-->
-    <!--    <mat-tab class="cron-editor-tab" label="Daily" *ngIf="!options.hideDailyTab" #dailyTab>
-      <div class="cron-editor-tab-content" [formGroup]="allForm">
+    <mat-tab  class="cron-editor-tab" label="Daily" *ngIf="!options.hideDailyTab" #dailyTab>
+      <div class="cron-editor-tab-content" [formGroup]="allForm" (click)="allForm.controls.cronType.setValue('daily')">
 
-        <mat-radio-group class="cron-editor-radio-group" formControlName="weekdaysOnly">
-          <mat-radio-button name="subTab" class="cron-editor-radio-button" value="false" [ngClass]="options.formRadioClass" checked="checked">
-
-            <span class="cron-form-label">Every </span>
-
-            <mat-form-field>
-              <mat-label>Day(s)</mat-label>
-              <mat-select formControlName="days">
-                <mat-option *ngFor="let monthDay of selectOptions.monthDays" [value]="monthDay">
-                  {{monthDay}}
-                </mat-option>
-              </mat-select>
-            </mat-form-field>
-
-              at
-
-            <cron-time-picker
-              formGroupName="allForm"
-              [use24HourTime]="options.use24HourTime"
-              [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
-            </cron-time-picker>
-
-          </mat-radio-button>
-
-          <mat-radio-button name="subTab" class="cron-editor-radio-button" value="true" [ngClass]="options.formRadioClass">
-
-            <span>Week Day (MON-FRI) at </span>
-
-            <cron-time-picker
-              formGroupName="allForm"
-              [use24HourTime]="options.use24HourTime"
-              [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
-            </cron-time-picker>
-
-          </mat-radio-button>
-        </mat-radio-group>
-      </div>
-    </mat-tab>-->
-
-    <!-- Weekly-->
-<!--    <mat-tab  class="cron-editor-tab" label="Weekly" *ngIf="!options.hideWeeklyTab" #weeklyTab>
-      <div class="cron-editor-tab-content">
-
-        <span class="cron-form-label">Every </span>
-
-        <div [formGroup]="allForm">
-          <mat-checkbox class="checkbox-margin" formControlName="MON">Monday</mat-checkbox>
-          <mat-checkbox class="checkbox-margin" formControlName="TUE">Tuesday</mat-checkbox>
-          <mat-checkbox class="checkbox-margin" formControlName="WED">Wednesday</mat-checkbox>
-          <mat-checkbox class="checkbox-margin" formControlName="THU">Thursday</mat-checkbox>
-          <mat-checkbox class="checkbox-margin" formControlName="FRI">Friday</mat-checkbox>
-          <mat-checkbox class="checkbox-margin" formControlName="SAT">Saturday</mat-checkbox>
-          <mat-checkbox class="checkbox-margin" formControlName="SUN">Sunday</mat-checkbox>
+        <div>
+          <span class="cron-form-label">Every </span>
+            <mat-radio-group class="cron-editor-radio-group" formControlName="weekdaysOnly" >
+              <mat-radio-button name="subTab" class="cron-editor-radio-button" [value]="false"  [checked]="true" [ngClass]="options.formRadioClass">
+                <mat-form-field>
+                  <mat-label>Day(s)</mat-label>
+                  <mat-select formControlName="daysPer">
+                    <mat-option *ngFor="let monthDay of selectOptions.monthDays" [value]="monthDay">
+                      {{monthDay}}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </mat-radio-button>
+              <mat-radio-button name="subTab" class="cron-editor-radio-button" [value]="true" [ngClass]="options.formRadioClass" >
+                <span>Week Day (MON-FRI) </span>
+              </mat-radio-button>
+            </mat-radio-group>
         </div>
 
-        <span class="cron-form-label">at time </span>
-
-        <cron-time-picker [formGroup]="allForm"
-                          [use24HourTime]="options.use24HourTime"
-                          [hideSeconds]="options.hideSeconds|| !isCronFlavorQuartz">
-        </cron-time-picker>
+        <div>
+          <span>At </span>
+          <cron-time-picker
+            [formGroup]="allForm"
+            [use24HourTime]="options.use24HourTime"
+            [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
+          </cron-time-picker>
+        </div>
       </div>
-    </mat-tab>-->
+
+    </mat-tab>
+
+    <!-- Weekly-->
+    <mat-tab  class="cron-editor-tab" label="Weekly" *ngIf="!options.hideWeeklyTab" #weeklyTab >
+      <div class="cron-editor-tab-content" (click)="allForm.controls.cronType.setValue('weekly')">
+
+        <div>
+          <span class="cron-form-label">Every</span>
+
+          <div [formGroup]="allForm">
+            <mat-checkbox class="checkbox-margin" formControlName="MON">Monday</mat-checkbox>
+            <mat-checkbox class="checkbox-margin" formControlName="TUE">Tuesday</mat-checkbox>
+            <mat-checkbox class="checkbox-margin" formControlName="WED">Wednesday</mat-checkbox>
+            <mat-checkbox class="checkbox-margin" formControlName="THU">Thursday</mat-checkbox>
+            <mat-checkbox class="checkbox-margin" formControlName="FRI">Friday</mat-checkbox>
+            <mat-checkbox class="checkbox-margin" formControlName="SAT">Saturday</mat-checkbox>
+            <mat-checkbox class="checkbox-margin" formControlName="SUN">Sunday</mat-checkbox>
+          </div>
+        </div>
+
+        <div>
+          <span class="cron-form-label"> At </span>
+          <cron-time-picker [formGroup]="allForm"
+                            [use24HourTime]="options.use24HourTime"
+                            [hideSeconds]="options.hideSeconds|| !isCronFlavorQuartz">
+          </cron-time-picker>
+        </div>
+      </div>
+    </mat-tab>
 
     <!-- Monthly-->
-<!--    <mat-tab class="cron-editor-tab" label="Monthly" *ngIf="!options.hideMonthlyTab" #monthlyTab>
-      <div class="cron-editor-tab-content" [formGroup]="allForm">
-        <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
+    <mat-tab class="cron-editor-tab" label="Monthly" *ngIf="!options.hideMonthlyTab" #monthlyTab>
+      <div class="cron-editor-tab-content" [formGroup]="allForm" (click)="allForm.controls.cronType.setValue('monthly')">
 
-          <mat-radio-button name="monthly-radio" class="cron-editor-radio-button" value="specificDay" [ngClass]="state.formRadioClass">
-            &lt;!&ndash; Spesific day &ndash;&gt;
-            <span formGroupName="specificDay">
+        <mat-radio-group class="cron-editor-radio-group" formControlName="specificWeekDay">
+          <mat-radio-button name="monthly-radio" class="cron-editor-radio-button" [value]="false" [ngClass]="options.formRadioClass">
+            <!-- Spesific day -->
 
               On the
 
@@ -118,7 +140,7 @@
               <ng-container *ngIf="options.cronFlavor === 'standard'">
                 <mat-form-field>
                   <mat-label>Day</mat-label>
-                  <mat-select class="month-days"  formControlName="day">
+                  <mat-select class="month-days" formControlName="day">
                     <mat-option *ngFor="let monthDaysWithOutLast of selectOptions.monthDaysWithOutLasts" [value]="monthDaysWithOutLast">
                       {{monthDayDisplay(monthDaysWithOutLast)}}
                     </mat-option>
@@ -128,7 +150,6 @@
 
               of every
 
-              <ng-container>
                 <mat-form-field>
                   <mat-label>Month</mat-label>
                   <mat-select class="months-small" formControlName="months" [ngClass]="options.formSelectClass">
@@ -137,26 +158,17 @@
                     </mat-option>
                   </mat-select>
                 </mat-form-field>
-              </ng-container>
 
-              at time
-
-              <cron-time-picker [disabled]="disabled" [formGroup]="allForm"
-                                [use24HourTime]="options.use24HourTime"
-                                [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
-              </cron-time-picker>
-            </span>
           </mat-radio-button>
 
-          <mat-radio-button name="monthly-radio" class="cron-editor-radio-button" value="specificWeekDay" [ngClass]="state.formRadioClass">
-            &lt;!&ndash; Spesific Week day &ndash;&gt;
-            <span formGroupName="specificWeekDay">
+          <mat-radio-button name="monthly-radio" class="cron-editor-radio-button"  [value]="true" [ngClass]="options.formRadioClass">
+            <!-- Spesific Week day -->
 
               On the
 
               <mat-form-field>
                 <mat-label>Week</mat-label>
-                <mat-select class="day-order-in-month" formControlName="monthWeek" [ngClass]="options.formSelectClass">
+                <mat-select class="day-order-in-month" formControlName="montshWeek" [ngClass]="options.formSelectClass">
                   <mat-option *ngFor="let monthWeek of selectOptions.monthWeeks" [value]="monthWeek">
                     {{monthWeekDisplay(monthWeek)}}
                   </mat-option>
@@ -182,29 +194,28 @@
                   </mat-option>
                 </mat-select>
               </mat-form-field>
-
-              at time
-
-              <cron-time-picker [formGroup]="allForm"
-                                [use24HourTime]="options.use24HourTime"
-                                [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
-              </cron-time-picker>
-            </span>
           </mat-radio-button>
-
         </mat-radio-group>
+
+        <div>
+          <span>At </span>
+          <cron-time-picker [formGroup]="allForm"
+                            [use24HourTime]="options.use24HourTime"
+                            [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
+          </cron-time-picker>
+        </div>
       </div>
-    </mat-tab>-->
+    </mat-tab>
 
     <!-- Yearly-->
-<!--    <mat-tab class="cron-editor-tab"  label="Yearly" *ngIf="!options.hideYearlyTab" #yearlyTab>
-      <div class="cron-editor-tab-content" [formGroup]="yearlyForm">
-        <mat-radio-group class="cron-editor-radio-group" formControlName="subTab">
-          <mat-radio-button name="yearly-radio" class="cron-editor-radio-button" value="specificMonthDay" [ngClass]="state.formRadioClass">
+    <mat-tab class="cron-editor-tab"  label="Yearly" *ngIf="!options.hideYearlyTab" #yearlyTab>
+      <div class="cron-editor-tab-content" [formGroup]="allForm">
+        <mat-radio-group class="cron-editor-radio-group" formControlName="specificMonthWeek">
+          <mat-radio-button name="yearly-radio" class="cron-editor-radio-button" [value]="false" [ngClass]="options.formRadioClass">
 
             On the
 
-            <mat-form-field formGroupName="specificMonthDay" *ngIf="options.cronFlavor === 'quartz'">
+            <mat-form-field  *ngIf="options.cronFlavor === 'quartz'">
               <mat-label>Day</mat-label>
               <mat-select class="month-days" formControlName="day">
                 <mat-option *ngFor="let monthDaysWithLast of selectOptions.monthDaysWithLasts" [value]="monthDaysWithLast">
@@ -213,7 +224,7 @@
               </mat-select>
             </mat-form-field>
 
-            <mat-form-field formGroupName="specificMonthDay" *ngIf="options.cronFlavor === 'standard'">
+            <mat-form-field *ngIf="options.cronFlavor === 'standard'">
               <mat-label>Day</mat-label>
               <mat-select class="month-days" formControlName="day" >
                 <mat-option *ngFor="let monthDaysWithOutLast of selectOptions.monthDaysWithOutLasts" [value]="monthDaysWithOutLast">
@@ -224,38 +235,31 @@
 
             of
 
-            <mat-form-field formGroupName="specificMonthDay">
+            <mat-form-field>
               <mat-label>Month</mat-label>
-              <mat-select class="months" formControlName="month">
+              <mat-select class="months" formControlName="months">
                 <mat-option *ngFor="let month of selectOptions.months" [value]="month">
                   {{monthDisplay(month)}}
                 </mat-option>
               </mat-select>
             </mat-form-field>
 
-            at time
-
-            <cron-time-picker [disabled]="disabled"
-                              [formGroup]="allForm"
-                              [use24HourTime]="options.use24HourTime"
-                              [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
-            </cron-time-picker>
           </mat-radio-button>
 
-          <mat-radio-button name="yearly-radio" class="cron-editor-radio-button" value="specificMonthWeek" [ngClass]="state.formRadioClass">
+          <mat-radio-button name="yearly-radio" class="cron-editor-radio-button" value="specificMonthWeek" [ngClass]="options.formRadioClass">
 
             On the
 
-            <mat-form-field formGroupName="specificMonthWeek">
+            <mat-form-field >
               <mat-label>Week</mat-label>
-              <mat-select class="day-order-in-month" formControlName="monthWeek" >
+              <mat-select class="day-order-in-month" formControlName="monthsWeek" >
                 <mat-option *ngFor="let monthWeek of selectOptions.monthWeeks" [value]="monthWeek">
                   {{monthWeekDisplay(monthWeek)}}
                 </mat-option>
               </mat-select>
             </mat-form-field>
 
-            <mat-form-field formGroupName="specificMonthWeek">
+            <mat-form-field>
               <mat-label>Day</mat-label>
               <mat-select class="week-days"  formControlName="day" >
                 <mat-option *ngFor="let day of selectOptions.days" [value]="day">
@@ -266,36 +270,39 @@
 
             of
 
-            <mat-form-field formGroupName="specificMonthWeek">
+            <mat-form-field>
               <mat-label>Month</mat-label>
-              <mat-select class="months" formControlName="month">
+              <mat-select class="months" formControlName="months">
                 <mat-option *ngFor="let month of selectOptions.months" [value]="month">
                   {{monthDisplay(month)}}
                 </mat-option>
               </mat-select>
             </mat-form-field>
 
-            at time
-
-            <cron-time-picker [disabled]="disabled"
-                              [formGroup]="allForm"
-                              [use24HourTime]="options.use24HourTime"
-                              [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
-            </cron-time-picker>
           </mat-radio-button>
         </mat-radio-group>
+
+        <div>
+        at time
+          <cron-time-picker [disabled]="disabled"
+                            [formGroup]="allForm"
+                            [use24HourTime]="options.use24HourTime"
+                            [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
+          </cron-time-picker>
+        </div>
+
       </div>
-    </mat-tab>-->
+    </mat-tab>
 
     <!-- Advanced-->
-<!--    <mat-tab class="cron-editor-tab" label="Advanced" *ngIf="!options.hideAdvancedTab" #advancedTab>
-      <div class="cron-editor-tab-content" [formGroup]="advancedForm">
+    <mat-tab class="cron-editor-tab" label="Advanced" *ngIf="!options.hideAdvancedTab" #advancedTab>
+      <div class="cron-editor-tab-content" [formGroup]="allForm">
         <mat-form-field>
           <mat-label>Expression</mat-label>
           <input matInput type="text" class="advanced-cron-editor-input" formControlName="expression">
         </mat-form-field>
       </div>
-    </mat-tab>-->
+    </mat-tab>
 
 
 

--- a/libs/ngx-cron-editor/src/cron-editor.template.html
+++ b/libs/ngx-cron-editor/src/cron-editor.template.html
@@ -16,7 +16,7 @@
         </div>
 
         <div *ngIf="isCronFlavorQuartz">
-          <span> At </span>
+          <span>At time </span>
           <cron-time-picker
             [formGroup]="allForm"
             [hideHours] = true
@@ -42,7 +42,7 @@
           </mat-form-field>
         </div>
         <div>
-          <span> At </span>
+          <span>At time </span>
           <cron-time-picker
               [formGroup]="allForm"
               [hideHours] = true
@@ -55,12 +55,12 @@
 
     <!-- Daily-->
     <mat-tab  class="cron-editor-tab" label="Daily" *ngIf="!options.hideDailyTab" #dailyTab>
-      <div class="cron-editor-tab-content" [formGroup]="allForm" (click)="allForm.controls.cronType.setValue('daily')">
+      <div class="cron-editor-tab-content" (click)="allForm.controls.cronType.setValue('daily')">
 
-        <div>
+        <div [formGroup]="allForm">
           <span class="cron-form-label">Every </span>
             <mat-radio-group class="cron-editor-radio-group" formControlName="weekdaysOnly" >
-              <mat-radio-button name="subTab" class="cron-editor-radio-button" [value]="false"  [checked]="true" [ngClass]="options.formRadioClass">
+              <mat-radio-button name="subTab" class="cron-editor-radio-button" [value]="false"  [checked]="true" >
                 <mat-form-field>
                   <mat-label>Day(s)</mat-label>
                   <mat-select formControlName="daysPer">
@@ -70,14 +70,14 @@
                   </mat-select>
                 </mat-form-field>
               </mat-radio-button>
-              <mat-radio-button name="subTab" class="cron-editor-radio-button" [value]="true" [ngClass]="options.formRadioClass" >
+              <mat-radio-button name="subTab" class="cron-editor-radio-button" [value]="true">
                 <span>Week Day (MON-FRI) </span>
               </mat-radio-button>
             </mat-radio-group>
         </div>
 
         <div>
-          <span>At </span>
+          <span>At time </span>
           <cron-time-picker
             [formGroup]="allForm"
             [use24HourTime]="options.use24HourTime"
@@ -129,7 +129,7 @@
               <ng-container *ngIf="options.cronFlavor === 'quartz'">
                 <mat-form-field>
                   <mat-label>Day</mat-label>
-                  <mat-select class="month-days" formControlName="day">
+                  <mat-select class="month-days" formControlName="days">
                     <mat-option *ngFor="let monthDaysWithLast of selectOptions.monthDaysWithLasts" [value]="monthDaysWithLast">
                       {{monthDayDisplay(monthDaysWithLast)}}
                     </mat-option>
@@ -140,7 +140,7 @@
               <ng-container *ngIf="options.cronFlavor === 'standard'">
                 <mat-form-field>
                   <mat-label>Day</mat-label>
-                  <mat-select class="month-days" formControlName="day">
+                  <mat-select class="month-days" formControlName="days">
                     <mat-option *ngFor="let monthDaysWithOutLast of selectOptions.monthDaysWithOutLasts" [value]="monthDaysWithOutLast">
                       {{monthDayDisplay(monthDaysWithOutLast)}}
                     </mat-option>
@@ -152,7 +152,7 @@
 
                 <mat-form-field>
                   <mat-label>Month</mat-label>
-                  <mat-select class="months-small" formControlName="months" [ngClass]="options.formSelectClass">
+                  <mat-select class="months-small" formControlName="monthsInc" [ngClass]="options.formSelectClass">
                     <mat-option *ngFor="let month of selectOptions.months" [value]="month">
                       {{month}}
                     </mat-option>
@@ -168,7 +168,7 @@
 
               <mat-form-field>
                 <mat-label>Week</mat-label>
-                <mat-select class="day-order-in-month" formControlName="montshWeek" [ngClass]="options.formSelectClass">
+                <mat-select class="day-order-in-month" formControlName="monthsWeek" [ngClass]="options.formSelectClass">
                   <mat-option *ngFor="let monthWeek of selectOptions.monthWeeks" [value]="monthWeek">
                     {{monthWeekDisplay(monthWeek)}}
                   </mat-option>
@@ -188,7 +188,7 @@
 
               <mat-form-field>
                 <mat-label>Month</mat-label>
-                <mat-select class="months-small" formControlName="months">
+                <mat-select class="months-small" formControlName="monthsInc">
                   <mat-option *ngFor="let month of selectOptions.months" [value]="month">
                     {{month}}
                   </mat-option>
@@ -198,7 +198,7 @@
         </mat-radio-group>
 
         <div>
-          <span>At </span>
+          <span>At time </span>
           <cron-time-picker [formGroup]="allForm"
                             [use24HourTime]="options.use24HourTime"
                             [hideSeconds]="options.hideSeconds || !isCronFlavorQuartz">
@@ -283,7 +283,7 @@
         </mat-radio-group>
 
         <div>
-        at time
+        At time
           <cron-time-picker [disabled]="disabled"
                             [formGroup]="allForm"
                             [use24HourTime]="options.use24HourTime"

--- a/libs/ngx-cron-editor/src/cron-time-picker.component.ts
+++ b/libs/ngx-cron-editor/src/cron-time-picker.component.ts
@@ -21,7 +21,7 @@ function* range(start: number, end: number) {
   providers: []
 })
 export class TimePickerComponent {
-  @Input() public disabled;
+  @Input() public disabled = false;
   @Input() public use24HourTime = true;
   @Input() public hideHours = false;
   @Input() public hideMinutes = false;

--- a/libs/ngx-cron-editor/src/cron-time-picker.component.ts
+++ b/libs/ngx-cron-editor/src/cron-time-picker.component.ts
@@ -1,6 +1,5 @@
-﻿import { Component, Input } from '@angular/core';
-import { ControlContainer } from '@angular/forms';
-
+﻿import {Component, Input, OnInit} from '@angular/core';
+import {ControlContainer, FormGroup} from '@angular/forms';
 
 export interface TimePickerModel {
   days: number;
@@ -20,12 +19,14 @@ function* range(start: number, end: number) {
   templateUrl: './cron-time-picker.template.html',
   providers: []
 })
-export class TimePickerComponent {
+export class TimePickerComponent implements OnInit {
   @Input() public disabled = false;
   @Input() public use24HourTime = true;
   @Input() public hideHours = false;
   @Input() public hideMinutes = false;
   @Input() public hideSeconds = true;
+
+  allForm: FormGroup;
 
   public minutes =  [...range(0, 59) ];
   public seconds = [...range(0, 59) ];
@@ -35,7 +36,11 @@ export class TimePickerComponent {
     return this.use24HourTime ? [... range(0, 23)] : [... range(0, 12)];
   }
 
-  constructor(public parent: ControlContainer) { }
+  constructor(public parent: ControlContainer) {}
+
+  ngOnInit(): void {
+    this.allForm = this.parent.control as FormGroup;
+  }
 }
 
 

--- a/libs/ngx-cron-editor/src/cron-time-picker.template.html
+++ b/libs/ngx-cron-editor/src/cron-time-picker.template.html
@@ -1,4 +1,5 @@
-<span [formGroup]="parent.control">
+<ng-container [formGroup]="allForm">
+
   <ng-container *ngIf="!hideHours">
     <mat-form-field>
       <mat-label>Hour(s)</mat-label>
@@ -36,4 +37,4 @@
       </mat-select>
     </mat-form-field>
   </ng-container>
-</span>
+</ng-container>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-cron-editor",
-  "version": "0.7.8",
+  "version": "0.7.9-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-cron-editor",
-      "version": "0.7.8",
+      "version": "0.7.9-0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^16.1.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Ruslan Lekhman <lekhman112@gmail.com> (https://github.com/lekhmanrus)",
     "Hannes Oswald <hannes.oswald@prolion.com>"
   ],
-  "version": "0.7.8",
+  "version": "0.7.9-0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
fix: cron expression loads from input

This PR rewires the internals of the cron-editor so that state is shared between all tabs. Input cron expressions are also parsed initially and on updates. 

resolves #15 

