### PR TITLE
i18n is missing in one text on Monthly tab

### DIFF
--- a/libs/ngx-cron-editor/src/cron-editor.template.html
+++ b/libs/ngx-cron-editor/src/cron-editor.template.html
@@ -184,7 +184,7 @@
                 </mat-select>
               </mat-form-field>
 
-              of every
+              <ng-container i18n>of every</ng-container>
 
               <mat-form-field>
                 <mat-label i18n>Month</mat-label>


### PR DESCRIPTION
I'm using the library with the localization and when I was translating each word I saw that one word isn't translated. So, I checked and detected where the i18n attribute was missing.